### PR TITLE
fix StarVertex bugs when using LazyGetter

### DIFF
--- a/unipop-elastic/src/org/unipop/elastic/controller/star/ElasticStarVertex.java
+++ b/unipop-elastic/src/org/unipop/elastic/controller/star/ElasticStarVertex.java
@@ -61,8 +61,9 @@ public class ElasticStarVertex extends ElasticVertex<ElasticStarController> {
 
     @Override
     public void applyLazyFields(String label, Map<String, Object> properties) {
-        innerEdgeControllers.stream().map(controller -> controller.parseEdges(this, properties)).flatMap(Collection::stream).forEach(this::addInnerEdge);
-        super.applyLazyFields(label, properties);
+        HashMap<String, Object> clone = new HashMap<>(properties);
+        innerEdgeControllers.stream().map(controller -> controller.parseEdges(this, clone)).flatMap(Collection::stream).forEach(this::addInnerEdge);
+        super.applyLazyFields(label, clone);
     }
 
     public Set<BaseEdge> getInnerEdges(Predicates predicates) {

--- a/unipop-elastic/src/org/unipop/elastic/controller/star/inneredge/InnerEdge.java
+++ b/unipop-elastic/src/org/unipop/elastic/controller/star/inneredge/InnerEdge.java
@@ -6,16 +6,16 @@ import org.unipop.structure.BaseEdge;
 
 import java.util.Map;
 
-public abstract class InnerEdge extends BaseEdge {
+public abstract class InnerEdge<T extends InnerEdgeController> extends BaseEdge {
 
-    private final InnerEdgeController mapping;
+    private final T innerEdgeController;
 
-    public InnerEdge(ElasticStarVertex starVertex, Object edgeId, String edgeLabel, InnerEdgeController mapping, Vertex outVertex, Vertex inVertex, Map<String, Object> keyValues) {
-        super(edgeId, edgeLabel, keyValues, outVertex, inVertex, starVertex.getController(), starVertex.getGraph());
-        this.mapping = mapping;
+    public InnerEdge(ElasticStarVertex starVertex, Object edgeId, String edgeLabel, T innerEdgeController, Vertex outVertex, Vertex inVertex) {
+        super(edgeId, edgeLabel, null, outVertex, inVertex, starVertex.getController(), starVertex.getGraph());
+        this.innerEdgeController = innerEdgeController;
     }
 
-    public InnerEdgeController getInnerEdgeController() {
-        return mapping;
+    public T getInnerEdgeController() {
+        return innerEdgeController;
     }
 }

--- a/unipop-elastic/src/org/unipop/elastic/controller/star/inneredge/nested/NestedEdge.java
+++ b/unipop-elastic/src/org/unipop/elastic/controller/star/inneredge/nested/NestedEdge.java
@@ -9,14 +9,19 @@ import org.unipop.structure.BaseProperty;
 
 import java.util.Map;
 
-public class NestedEdge extends InnerEdge {
+public class NestedEdge extends InnerEdge<NestedEdgeController> {
 
     private ElasticStarVertex starVertex;
 
-    public NestedEdge(ElasticStarVertex starVertex, Object edgeId, String edgeLabel, InnerEdgeController mapping, Vertex outVertex, Vertex inVertex, Map<String, Object> keyValues) {
-        super(starVertex, edgeId, edgeLabel, mapping, outVertex, inVertex, keyValues);
+    public NestedEdge(ElasticStarVertex starVertex, Object edgeId, String edgeLabel, NestedEdgeController mapping, Vertex outVertex, Vertex inVertex) {
+        super(starVertex, edgeId, edgeLabel, mapping, outVertex, inVertex);
         this.starVertex = starVertex;
 
+    }
+
+    @Override
+    protected boolean shouldAddProperty(String key) {
+        return super.shouldAddProperty(key) && getInnerEdgeController().shouldAddProperty(key);
     }
 
     @Override

--- a/unipop-elastic/src/org/unipop/elastic/controller/star/inneredge/nested/NestedEdgeController.java
+++ b/unipop-elastic/src/org/unipop/elastic/controller/star/inneredge/nested/NestedEdgeController.java
@@ -41,7 +41,8 @@ public class NestedEdgeController implements InnerEdgeController {
         if (!label.equals(edgeLabel)) return null;
         ElasticStarVertex starVertex = (ElasticStarVertex) (direction.equals(Direction.IN) ? inV : outV);
         if (!starVertex.label().equals(vertexLabel)) return null;
-        NestedEdge edge = new NestedEdge(starVertex, edgeId, edgeLabel, this, outV, inV, properties);
+        NestedEdge edge = new NestedEdge(starVertex, edgeId, edgeLabel, this, outV, inV);
+        properties.forEach((key, value) -> edge.addPropertyLocal(key, value));
         starVertex.addInnerEdge(edge);
         starVertex.update();
         return edge;
@@ -63,13 +64,12 @@ public class NestedEdgeController implements InnerEdgeController {
 
     private InnerEdge parseEdge(ElasticStarVertex vertex, Map<String, Object> keyValues) {
         Object externalVertexId = keyValues.get(externalVertexIdField);
-        keyValues.remove(externalVertexIdField);
         Object edgeId = keyValues.get(edgeIdField);
-        keyValues.remove(edgeIdField);
         BaseVertex externalVertex = vertex.getGraph().getControllerManager().fromEdge(direction.opposite(), externalVertexId, externalVertexLabel);
         BaseVertex outV = direction.equals(Direction.OUT) ? vertex : externalVertex;
         BaseVertex inV = direction.equals(Direction.IN) ? vertex : externalVertex;
-        NestedEdge edge = new NestedEdge(vertex, edgeId, edgeLabel, this, outV, inV, keyValues);
+        NestedEdge edge = new NestedEdge(vertex, edgeId, edgeLabel, this, outV, inV);
+        keyValues.forEach((key, value) -> edge.addPropertyLocal(key, value));
         vertex.addInnerEdge(edge);
         return edge;
     }
@@ -156,5 +156,9 @@ public class NestedEdgeController implements InnerEdgeController {
 
     public Direction getDirection() {
         return direction;
+    }
+
+    public boolean shouldAddProperty(String key) {
+        return !externalVertexIdField.equals(key) && !edgeIdField.equals(key);
     }
 }


### PR DESCRIPTION
1. Clone properties map because we remove the nested documents.
2. Don't add externalVertexIdField & edgeIdField as properties;